### PR TITLE
Copy Prisma schema into API runtime image

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -22,6 +22,7 @@ USER node
 COPY --chown=node:node --from=builder /app/node_modules ./node_modules
 COPY --chown=node:node --from=builder /app/src ./src
 COPY --chown=node:node --from=builder /app/package.json ./package.json
+COPY --chown=node:node --from=builder /app/prisma ./prisma
 EXPOSE 8080
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 CMD node -e "fetch('http://localhost:8080/healthz').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"
 CMD ["sh", "-c", "npx prisma db push && node src/index.js"]


### PR DESCRIPTION
## Summary
- ensure Prisma schema copied into API runtime Docker image so prisma commands run at startup

## Testing
- `npm run prisma:generate`
- `docker compose build api` *(fails: `bash: command not found: docker`)*

------
https://chatgpt.com/codex/tasks/task_e_68b0ebd410d48322987612333a581e61